### PR TITLE
Adding a function and testing for converting a square matrix back to its corresponding rectangular matrix

### DIFF
--- a/VirusHostNetworkAnalysis/prediction_matrix.py
+++ b/VirusHostNetworkAnalysis/prediction_matrix.py
@@ -142,6 +142,14 @@ class PredictionMatrix:
         self.make_rectangular_matrix(matrix_type.lower())
         self.expand_matrix(matrix_type.lower())
         return self.virus_host_array_square
+    
+    def square_to_rectangular_matrix(self, matric_type:str):
+        """Convert the Square matrix back into the original rectangular matrix"""
+        self.get_unique_virus_host()
+        unique_virus_count = len(set(self.unique_viruses))
+        unique_host_count = len(set(self.unique_hosts))
+        self.virus_host_array = self.virus_host_array[:unique_virus_count, :unique_host_count]
+        return self.virus_host_array
 
     def plot_heatmap(self, matrix_type:str):
         # if matrix type prediction, use purples, otherwise use warm colors


### PR DESCRIPTION
Files updated in this request: 
VirusHostNetworkAnalysis/prediction_matrix.py— added the function square_to_rectangular_matrix which assumes that self.virus_host_array is currently a square matrix, and will update self.virus_host_array to keep only rows and columns corresponding to the original rectangular matrix

test_updated.ipynb— added as section to verify that the function is able to behave as expected
